### PR TITLE
Pin fixed Pages CMS image uploads

### DIFF
--- a/deploy/pagescms/README.md
+++ b/deploy/pagescms/README.md
@@ -6,7 +6,7 @@ localhost. Pages CMS also listens only on `127.0.0.1:3000`; Tailscale Serve
 provides the private HTTPS endpoint.
 
 The release builder uses `fnm` and pins the personal Pages CMS fork to commit
-`a381d7a9345777e80711a295687d962cdae3bd2b`. The fork contains the
+`f8b82455e303bb22ca7b603ba091ea9c1cd7a098`. The fork contains the
 private-email login fallback, timestamp buttons, and browser-side WebP upload
 conversion used by this blog.
 
@@ -150,7 +150,9 @@ The fork converts new JPEG and PNG uploads to WebP in the browser at quality 82
 before they are sent to Pages CMS or GitHub. This covers the media library,
 image fields such as `Social image`, and rich-text image paste/drop. Existing
 repository images are not rewritten, and WebP, GIF, SVG, and non-image files
-pass through unchanged.
+pass through unchanged. Oversized images are reduced to browser-safe canvas
+dimensions, and a failed rich-text upload cannot leave a temporary `blob:` URL
+in saved content.
 
 Back up the CMS database:
 

--- a/deploy/pagescms/scripts/build-release.sh
+++ b/deploy/pagescms/scripts/build-release.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 PAGESCMS_ROOT=${PAGESCMS_ROOT:-/opt/pagescms}
 PAGESCMS_REPOSITORY=${PAGESCMS_REPOSITORY:-https://github.com/YieumYoon/pagescms.git}
-PAGESCMS_COMMIT=${PAGESCMS_COMMIT:-a381d7a9345777e80711a295687d962cdae3bd2b}
+PAGESCMS_COMMIT=${PAGESCMS_COMMIT:-f8b82455e303bb22ca7b603ba091ea9c1cd7a098}
 NODE_VERSION=${NODE_VERSION:-24}
 
 if [[ $(id -un) != pagescms ]]; then


### PR DESCRIPTION
## What changed

- pin the Oracle release builder to Pages CMS fork commit `f8b82455e303bb22ca7b603ba091ea9c1cd7a098`
- document large-image conversion safeguards and prevention of saved temporary `blob:` URLs

## Why

A failed rich-text image conversion left its browser-only preview URL in Markdown, producing a broken image after save. The pinned fork commit adds robust image decoding/resizing, removes failed temporary uploads, blocks saves while image uploads are pending, and fixes the Better Auth cookie-plugin order.

## Validation

- Pages CMS ESLint: 0 errors (existing warnings only)
- Pages CMS Next.js 16.2.10 production build passed
- deployment shell script syntax check passed
