### PR TITLE
Pin Safari WebP upload fallback

### DIFF
--- a/deploy/pagescms/README.md
+++ b/deploy/pagescms/README.md
@@ -6,7 +6,7 @@ localhost. Pages CMS also listens only on `127.0.0.1:3000`; Tailscale Serve
 provides the private HTTPS endpoint.
 
 The release builder uses `fnm` and pins the personal Pages CMS fork to commit
-`f8b82455e303bb22ca7b603ba091ea9c1cd7a098`. The fork contains the
+`34954af9d0cb491cf8e3840e3df5379da2c1b223`. The fork contains the
 private-email login fallback, timestamp buttons, and browser-side WebP upload
 conversion used by this blog.
 
@@ -152,7 +152,9 @@ image fields such as `Social image`, and rich-text image paste/drop. Existing
 repository images are not rewritten, and WebP, GIF, SVG, and non-image files
 pass through unchanged. Oversized images are reduced to browser-safe canvas
 dimensions, and a failed rich-text upload cannot leave a temporary `blob:` URL
-in saved content.
+in saved content. Browsers that cannot encode WebP, including affected Safari
+versions, send the original JPEG or PNG to Pages CMS for server-side WebP
+conversion before the file is committed to GitHub.
 
 Back up the CMS database:
 

--- a/deploy/pagescms/scripts/build-release.sh
+++ b/deploy/pagescms/scripts/build-release.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 PAGESCMS_ROOT=${PAGESCMS_ROOT:-/opt/pagescms}
 PAGESCMS_REPOSITORY=${PAGESCMS_REPOSITORY:-https://github.com/YieumYoon/pagescms.git}
-PAGESCMS_COMMIT=${PAGESCMS_COMMIT:-f8b82455e303bb22ca7b603ba091ea9c1cd7a098}
+PAGESCMS_COMMIT=${PAGESCMS_COMMIT:-34954af9d0cb491cf8e3840e3df5379da2c1b223}
 NODE_VERSION=${NODE_VERSION:-24}
 
 if [[ $(id -un) != pagescms ]]; then


### PR DESCRIPTION
## What changed

- pin the Oracle release builder to Pages CMS fork commit `34954af9d0cb491cf8e3840e3df5379da2c1b223`
- document the Safari-compatible server-side WebP fallback

## Why

Some Safari versions can display WebP but cannot encode WebP through the Canvas API. The browser now falls back to uploading the original JPEG or PNG, and Pages CMS converts it to WebP with Sharp before committing it to GitHub.

## Impact

Media-library uploads, Social image fields, and rich-text paste/drop now work from affected Safari versions while Chrome continues to convert in the browser.

## Validation

- server conversion test: PNG to WebP succeeded
- oversized 5,000×5,000 PNG reduced to 4,000×4,000 WebP (16MP)
- Pages CMS ESLint: 0 errors (existing warnings only)
- Pages CMS Next.js 16.2.10 production build passed
- deployment shell script syntax check passed
